### PR TITLE
Add support for psycopg2 smart driver

### DIFF
--- a/.github/workflows/django_3.2_test.yml
+++ b/.github/workflows/django_3.2_test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
 name: django-3.2-tests
 jobs:
   system-tests:

--- a/.github/workflows/django_4.0_test.yml
+++ b/.github/workflows/django_4.0_test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
 name: django-4.0-tests
 jobs:
   system-tests:

--- a/.github/workflows/django_4.1_test.yml
+++ b/.github/workflows/django_4.1_test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
 name: django-4.1-tests
 jobs:
   system-tests:

--- a/.github/workflows/django_test.yml
+++ b/.github/workflows/django_test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+    branches:
+      - main
 name: django-tests
 jobs:
   system-tests:

--- a/README.rst
+++ b/README.rst
@@ -6,16 +6,17 @@ Prerequisites
 
 * GCC
 * Python 3.8 and above 
-* Psycopg2-binary
+* Psycopg2-yugabytedb (recommended)
 * Django 3.2 or above
 
 Need for Django Backend for YugabyteDB
 ---------------------------------------
 
-YugabyteDB needs a separate backend for Django. This is because of mainly 2 reasons.
+YugabyteDB needs a separate backend for Django. This is because of mainly 3 reasons.
 
 * Django tries to create Inet data types as primary keys in Django test suites. Since this is not supported, we map Inet types to varchar(15) and varchar(39) in the YB backend.  
 * We also need it to support type change from int to BigInt and numeric(m,n) to double precision. This is required  for Django DB migrations. For now, the YB backend ignores these type changes.
+* The Django PostgreSQL Backend does not support the Load Balance, even when used with YugabyteDB smart driver. 
   
 Installing from Pypi
 ---------------------
@@ -59,7 +60,38 @@ Update the ``DATABASES`` setting in your Django project's settings to point to Y
             'NAME': 'yugabyte',
             'HOST': 'localhost',
             'PORT': 5433,
-            'USER': 'yugabyte'
+            'USER': 'yugabyte',
+        }
+    }
+
+To use Cluster Aware Load Balance:
+
+.. code-block:: python
+
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django_yugabytedb',
+            'NAME': 'yugabyte',
+            'HOST': 'localhost',
+            'PORT': 5433,
+            'USER': 'yugabyte',
+            'LOAD_BALANCE': 'True'
+        }
+    }
+
+To use Topology Aware Load Balance:
+
+.. code-block:: python
+
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django_yugabytedb',
+            'NAME': 'yugabyte',
+            'HOST': 'localhost',
+            'PORT': 5433,
+            'USER': 'yugabyte',
+            'LOAD_BALANCE': 'True',
+            'TOPOLOGY_KEYS': 'cloud1.region1.zone1'
         }
     }
 

--- a/django_yugabytedb/base.py
+++ b/django_yugabytedb/base.py
@@ -56,3 +56,16 @@ class DatabaseWrapper(PGDatabaseWrapper):
         # https://code.djangoproject.com/ticket/32527
         # https://github.com/yugabyte/yugabyte-db/issues/7760
         #return 1
+
+    def get_connection_params(self):
+        conn_params =  super().get_connection_params()
+        settings_dict = self.settings_dict
+        load_balance = settings_dict.get("LOAD_BALANCE")
+        topology_keys = settings_dict.get("TOPOLOGY_KEYS")
+        if load_balance:
+            conn_params["load_balance"] = load_balance
+        if topology_keys:
+            conn_params["topology_keys"] = topology_keys
+        
+        return conn_params
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ asgiref>=3.3.1
 Django>=3.1.6
 pytz>=2021.1
 sqlparse>=0.4.1
-psycopg2-binary==2.8.6
+psycopg2-yugabytedb~=2.9.3.post0

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ except Exception:
     print("failed to read readme: ignoring...")
     readme = __doc__
 setup(name="django-yugabytedb",
-version = "4.0.0.post0",
+version = "4.0.0.post1",
 url = 'https://www.yugabyte.com/',
 author = 'Yugabyte',
 author_email = 'hbhanawat@yugabyte.com',


### PR DESCRIPTION
The postgresql backend for django does not pass `load_balance` and `topology_keys` in the connection params. Overriding that behaviour in our backend to support using django with YugabyteDB Psycopg2.