### PR TITLE
Add condition for versions less than 2.23 and 2024.2 onwards

### DIFF
--- a/django_yugabytedb/features.py
+++ b/django_yugabytedb/features.py
@@ -101,8 +101,10 @@ class DatabaseFeatures(PGDatabaseFeatures):
         expected_failures = base_expected_failures 
 
         yb_version = os.getenv('YB_VERSION')
+        yb_version_major = yb_version.split('.')[0]
+        yb_version_minor = yb_version.split('.')[1]
 
-        if yb_version[0:4] == '2024':
+        if (yb_version_major == '2024' and yb_version_minor == '1') or float(yb_version[0:4]) < 2.23:
             expected_failures.update({
                 # Alter table Add column Unique is not yet supported. 
                 # GH Issue: https://github.com/yugabyte/yugabyte-db/issues/1124


### PR DESCRIPTION
This PR is an extension of PR #7. The previous PR handled only cases for v2024 and v2.23. This PR changes the conditional statement based on the logic to include all possible versions of YugabyteDB:

versions >= 2.23 and onwards and  2024.2 and onwards will have the same behavior, ie, those 5 tests won't fail for them
and
< 2.23 and 2024.1 will have the same behavior, ie,  the tests will fail for them.